### PR TITLE
Added coaster tarball link to dependency_links

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,4 +50,7 @@ setup(name='baseframe',
       test_suite='tests',
       install_requires=requires,
       cmdclass={'build_py': BaseframeBuildPy},
+      dependency_links = [
+        "https://github.com/hasgeek/coaster/tarball/master#egg=coaster",
+      ]
       )


### PR DESCRIPTION
Makes `easy_install` use the provided tarball link instead of searching at pypi.
