### PR TITLE
WTForms>=2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requires = [
     'pytz',
     'pyIsEmail',
     'dnspython',
-    'wtforms',
+    'WTForms>=2.0',
     'Flask>=0.10.0',
     'Flask-Assets',
     'Flask-WTF',


### PR DESCRIPTION
WTForms is required to be greater than 2.0 as, wtforms.utils used in https://github.com/hasgeek/baseframe/blob/master/baseframe/forms/fields.py#L9 was introduced in the breaking change made in 2.0 as per https://wtforms.readthedocs.org/en/2.0/whats_new.html#deprecated-api-s