### PR TITLE
rm unnecessary line

### DIFF
--- a/baseframe/forms/fields.py
+++ b/baseframe/forms/fields.py
@@ -617,7 +617,6 @@ class FormField(wtforms.FormField):
     """
     def process(self, *args, **kwargs):
         retval = super(FormField, self).process(*args, **kwargs)
-        self.form.csrf_enabled = False
         del self.form.csrf_token
         return retval
 


### PR DESCRIPTION
Flask-WTF 0.14 has [deprecated](http://flask-wtf.readthedocs.io/en/stable/changelog.html) `csrf_enabled` and will remove this entirely in `1.0`.