### PR TITLE
Add GetDevicePixelRatio to baseframe assets

### DIFF
--- a/baseframe/assets.py
+++ b/baseframe/assets.py
@@ -249,6 +249,8 @@ assets['firamono.css'][Version('4.2.0')] = {'requires': [
 
 assets['baseframe-firasans.css'][Version('1.0.0')] = 'baseframe/css/baseframe-firasans.css'
 
+assets['getdevicepixelratio.js'][Version('1.0.0')] = 'baseframe/js/getdevicepixelratio.js'
+
 # Asset packages
 assets['bootstrap.js'][Version('2.0.1')] = {'requires': [
     'bootstrap-alert.js==2.0.1',
@@ -296,6 +298,7 @@ assets['extra.js'][Version('0.0.0')] = {'requires': [
     # 'bootstrap-datepicker.js',
     'jquery.timepicker.js',
     'select2-baseframe.js',
+    'getdevicepixelratio.js'
 ]}
 
 assets['baseframe.js'][Version(__version__)] = {'requires': [

--- a/baseframe/static/js/getdevicepixelratio.js
+++ b/baseframe/static/js/getdevicepixelratio.js
@@ -1,0 +1,2 @@
+/*! GetDevicePixelRatio | Author: Tyson Matanich, 2012 | License: MIT */
+(function(n){n.getDevicePixelRatio=function(){var t=1;return n.screen.systemXDPI!==undefined&&n.screen.logicalXDPI!==undefined&&n.screen.systemXDPI>n.screen.logicalXDPI?t=n.screen.systemXDPI/n.screen.logicalXDPI:n.devicePixelRatio!==undefined&&(t=n.devicePixelRatio),t}})(this);

--- a/baseframe/templates/baseframe.html
+++ b/baseframe/templates/baseframe.html
@@ -133,6 +133,9 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', {{ config['GA_CODE']|tojson }}, 'auto');
+      // Track Device Pixel Ratio
+      var pixelRatio = window.getDevicePixelRatio();
+      ga('set', 'metric1', pixelRatio);
       ga('send', 'pageview');
     </script>
   {%- endif -%}


### PR DESCRIPTION
Add GetDevicePixelRatio.js to get the device pixel ratio. 
Log pixel density as custom metric(metric1) into Google Analytics

Note:-
Pixel Ratio has been set as metric1 on GA account.
(https://support.google.com/analytics/answer/2709829#set_up_custom_metrics)