### PR TITLE
Baseframe form id

### DIFF
--- a/baseframe/forms/auto.py
+++ b/baseframe/forms/auto.py
@@ -18,9 +18,12 @@ class ConfirmDeleteForm(Form):
     cancel = SubmitField(__(u"Cancel"))
 
 
-def render_form(form, title, message='', formid='form', submit=__(u"Submit"), cancel_url=None, ajax=False, with_chrome=True):
+def render_form(form, title, message='', formid='', submit=__(u"Submit"), cancel_url=None, ajax=False, with_chrome=True):
     multipart = False
-    ref_id = 'form-' + buid()
+    if not formid:
+        ref_id = 'form-' + buid()
+    else:
+        ref_id = 'form-' + formid
     for field in form:
         if isinstance(field.widget, wtforms.widgets.FileInput):
             multipart = True

--- a/baseframe/forms/auto.py
+++ b/baseframe/forms/auto.py
@@ -18,12 +18,9 @@ class ConfirmDeleteForm(Form):
     cancel = SubmitField(__(u"Cancel"))
 
 
-def render_form(form, title, message='', formid='', submit=__(u"Submit"), cancel_url=None, ajax=False, with_chrome=True):
+def render_form(form, title, message='', formid=None, submit=__(u"Submit"), cancel_url=None, ajax=False, with_chrome=True):
     multipart = False
-    if not formid:
-        ref_id = 'form-' + buid()
-    else:
-        ref_id = 'form-' + formid
+    ref_id = 'form-' + (formid or buid())
     for field in form:
         if isinstance(field.widget, wtforms.widgets.FileInput):
             multipart = True


### PR DESCRIPTION
1. If client has passed a `formid`, prefix it with 'form-' and use it as id attribute for the form.
2. Incase the client doesn't pass a `formid`, generate one.