### PR TITLE
Add ajax post handler to Baseframe

### DIFF
--- a/baseframe/forms/auto.py
+++ b/baseframe/forms/auto.py
@@ -28,7 +28,7 @@ def render_form(form, title, message='', formid=None, submit=__(u"Submit"), canc
         template = THEME_FILES[current_app.config['theme']]['ajaxform.html.jinja2']
         return render_template(template, form=form, title=title,
             message=message, formid=formid, ref_id=ref_id, submit=submit,
-            cancel_url=cancel_url, ajax=ajax, multipart=multipart)
+            cancel_url=cancel_url, ajax=ajax, multipart=multipart, with_chrome=with_chrome)
     if request.is_xhr and ajax:
         template = THEME_FILES[current_app.config['theme']]['ajaxform.html.jinja2']
     else:

--- a/baseframe/static/js/baseframe-bootstrap.js
+++ b/baseframe/static/js/baseframe-bootstrap.js
@@ -298,14 +298,13 @@ window.Baseframe.Forms = {
    'formSelector' - Form selector to query the DOM for the form
    'onSuccess' - A callback function that is executed if the request succeeds
    'onError' - A callback function that is executed if the request fails
-   'config' -  An object that can contain data, contentType, dataType, 
-      beforeSend function
-    submitForm handles form submit, serializes the form values,
+   'config' -  An object that can contain data, contentType, dataType, beforeSend function
+    handleFormSubmit handles form submit, serializes the form values,
       disables the submit button to prevent double submit,
       displays the loading indicator and submits the form via ajax.
       On completing the ajax request, calls the onSuccess/onError callback function.
   */
-  submitForm: function(url, formSelector, onSuccess, onError, config) {
+  handleFormSubmit: function(url, formSelector, onSuccess, onError, config) {
     $(formSelector).find('button[type="submit"]').click(function(event) {
       event.preventDefault();
       $.ajax({

--- a/baseframe/static/js/baseframe-bootstrap.js
+++ b/baseframe/static/js/baseframe-bootstrap.js
@@ -254,8 +254,8 @@ window.Baseframe.Forms = {
       }
     })
   },
-  /* Takes 'formSelector' and 'errors'
-   'formSelector' is the form for which errors needs to be displayed
+  /* Takes 'formId' and 'errors'
+   'formId' is the id attribute of the form for which errors needs to be displayed
    'errors' is the WTForm validation errors expected in the following format
     {
       "title": [
@@ -271,8 +271,8 @@ window.Baseframe.Forms = {
     using the unique form id. And the newly created 'p' tag
     is inserted in the DOM below the field.
   */
-  showValidationErrors: function(formSelector, errors) {
-    var form = document.querySelector(formSelector);
+  showValidationErrors: function(formId, errors) {
+    var form = document.getElementById(formId);
     Object.keys(errors).forEach(function(fieldName) {
       if (Array.isArray(errors[fieldName])) {
         var fieldWrapper = form.querySelector("#field-" + fieldName);

--- a/baseframe/static/js/baseframe-bootstrap.js
+++ b/baseframe/static/js/baseframe-bootstrap.js
@@ -293,9 +293,9 @@ window.Baseframe.Forms = {
       }
     });
   },
-  /* Takes formSelector, url, onSuccess, onError, config
+  /* Takes formId, url, onSuccess, onError, config
+   'formId' - Form id selector to query the DOM for the form
    'url' - The url to which the post request is sent
-   'formSelector' - Form selector to query the DOM for the form
    'onSuccess' - A callback function that is executed if the request succeeds
    'onError' - A callback function that is executed if the request fails
    'config' -  An object that can contain dataType, beforeSend function
@@ -304,19 +304,19 @@ window.Baseframe.Forms = {
       displays the loading indicator and submits the form via ajax.
       On completing the ajax request, calls the onSuccess/onError callback function.
   */
-  handleFormSubmit: function(url, formSelector, onSuccess, onError, config) {
-    $(formSelector).find('button[type="submit"]').click(function(event) {
+  handleFormSubmit: function(formId, url, onSuccess, onError, config) {
+    $("#" + formId).find('button[type="submit"]').click(function(event) {
       event.preventDefault();
       $.ajax({
         url: url,
         type: 'POST',
-        data: $(formSelector).serialize(),
+        data: $("#" + formId).serialize(),
         dataType: config.dataType ? config.dataType : 'json',
         beforeSend: function() {
           // Disable submit button to prevent double submit
-          $(formSelector).find('button[type="submit"]').prop('disabled', true);
+          $("#" + formId).find('button[type="submit"]').prop('disabled', true);
           // Baseframe form has a loading indication which is hidden by default. Show the loading indicator
-          $(formSelector).find(".loading").removeClass('hidden');
+          $("#" + formId).find(".loading").removeClass('hidden');
           if (config.beforeSend) config.beforeSend();
         }
       }).done(function (remoteData) {

--- a/baseframe/static/js/baseframe-bootstrap.js
+++ b/baseframe/static/js/baseframe-bootstrap.js
@@ -299,8 +299,7 @@ window.Baseframe.Forms = {
    'onSuccess' - A callback function that is executed if the request succeeds
    'onError' - A callback function that is executed if the request fails
    'config' -  An object that can contain data, contentType, dataType, 
-      beforeSend function or any other data required by the client 
-      during the execution of the onSuccess/OnError callback
+      beforeSend function
     submitForm handles form submit, serializes the form values,
       disables the submit button to prevent double submit,
       displays the loading indicator and submits the form via ajax.

--- a/baseframe/static/js/baseframe-bootstrap.js
+++ b/baseframe/static/js/baseframe-bootstrap.js
@@ -312,8 +312,7 @@ window.Baseframe.Forms = {
       $.ajax({
         url: url,
         type: 'POST',
-        data: config.data ? config.data : $(formSelector).serialize(),
-        contentType : config.contentType ? config.contentType : 'application/x-www-form-urlencoded; charset=UTF-8',
+        data: $(formSelector).serialize(),
         dataType: config.dataType ? config.dataType : 'json',
         beforeSend: function() {
           // Disable submit button to prevent double submit

--- a/baseframe/static/js/baseframe-bootstrap.js
+++ b/baseframe/static/js/baseframe-bootstrap.js
@@ -292,6 +292,28 @@ window.Baseframe.Forms = {
         }
       }
     });
+  },
+  handleAjaxPost: function(config) {
+    $(config.formSelector).find('button[type="submit"]').click(function(event) {
+      event.preventDefault();
+      $.ajax({
+        url: config.url,
+        type: 'POST',
+        data: config.data ? config.data : $.param($(config.formSelector).serializeArray()),
+        contentType : config.contentType ? config.contentType : 'application/x-www-form-urlencoded; charset=UTF-8',
+        dataType: config.dataType ? config.dataType : 'json',
+        beforeSend: function() {
+          if (config.formSelector) {
+            $(config.formSelector).find('button[type="submit"]').prop('disabled', true);
+            $(config.formSelector).find(".loading").removeClass('hidden');
+          }
+        }
+      }).done(function (remoteData) {
+        config.onSuccess(config, remoteData);
+      }).fail(function (response) {
+        config.onError(config, response);
+      });
+    });
   }
 };
 

--- a/baseframe/static/js/baseframe-bootstrap.js
+++ b/baseframe/static/js/baseframe-bootstrap.js
@@ -322,9 +322,9 @@ window.Baseframe.Forms = {
           if (config.beforeSend) config.beforeSend();
         }
       }).done(function (remoteData) {
-        onSuccess(config, remoteData);
+        onSuccess(remoteData);
       }).fail(function (response) {
-        onError(config, response);
+        onError(response);
       });
     });
   }

--- a/baseframe/static/js/baseframe-bootstrap.js
+++ b/baseframe/static/js/baseframe-bootstrap.js
@@ -254,8 +254,8 @@ window.Baseframe.Forms = {
       }
     })
   },
-  /* Takes 'formId' and 'errors'
-   'formId' is the id attribute of the form for which errors needs to be displayed
+  /* Takes 'formSelector' and 'errors'
+   'formSelector' is the form for which errors needs to be displayed
    'errors' is the WTForm validation errors expected in the following format
     {
       "title": [
@@ -271,8 +271,8 @@ window.Baseframe.Forms = {
     using the unique form id. And the newly created 'p' tag
     is inserted in the DOM below the field.
   */
-  showValidationErrors: function(formId, errors) {
-    var form = document.getElementById(formId);
+  showValidationErrors: function(formSelector, errors) {
+    var form = document.querySelector(formSelector);
     Object.keys(errors).forEach(function(fieldName) {
       if (Array.isArray(errors[fieldName])) {
         var fieldWrapper = form.querySelector("#field-" + fieldName);
@@ -293,25 +293,39 @@ window.Baseframe.Forms = {
       }
     });
   },
-  handleAjaxPost: function(config) {
-    $(config.formSelector).find('button[type="submit"]').click(function(event) {
+  /* Takes formSelector, url, onSuccess, onError, config
+   'url' - The url to which the post request is sent
+   'formSelector' - Form selector to query the DOM for the form
+   'onSuccess' - A callback function that is executed if the request succeeds
+   'onError' - A callback function that is executed if the request fails
+   'config' -  An object that can contain data, contentType, dataType, 
+      beforeSend function or any other data required by the client 
+      during the execution of the onSuccess/OnError callback
+    submitForm handles form submit, serializes the form values,
+      disables the submit button to prevent double submit,
+      displays the loading indicator and submits the form via ajax.
+      On completing the ajax request, calls the onSuccess/onError callback function.
+  */
+  submitForm: function(url, formSelector, onSuccess, onError, config) {
+    $(formSelector).find('button[type="submit"]').click(function(event) {
       event.preventDefault();
       $.ajax({
-        url: config.url,
+        url: url,
         type: 'POST',
-        data: config.data ? config.data : $.param($(config.formSelector).serializeArray()),
+        data: config.data ? config.data : $(formSelector).serialize(),
         contentType : config.contentType ? config.contentType : 'application/x-www-form-urlencoded; charset=UTF-8',
         dataType: config.dataType ? config.dataType : 'json',
         beforeSend: function() {
-          if (config.formSelector) {
-            $(config.formSelector).find('button[type="submit"]').prop('disabled', true);
-            $(config.formSelector).find(".loading").removeClass('hidden');
-          }
+          // Disable submit button to prevent double submit
+          $(formSelector).find('button[type="submit"]').prop('disabled', true);
+          // Baseframe form has a loading indication which is hidden by default. Show the loading indicator
+          $(formSelector).find(".loading").removeClass('hidden');
+          if (config.beforeSend) config.beforeSend();
         }
       }).done(function (remoteData) {
-        config.onSuccess(config, remoteData);
+        onSuccess(config, remoteData);
       }).fail(function (response) {
-        config.onError(config, response);
+        onError(config, response);
       });
     });
   }

--- a/baseframe/static/js/baseframe-bootstrap.js
+++ b/baseframe/static/js/baseframe-bootstrap.js
@@ -298,7 +298,7 @@ window.Baseframe.Forms = {
    'formSelector' - Form selector to query the DOM for the form
    'onSuccess' - A callback function that is executed if the request succeeds
    'onError' - A callback function that is executed if the request fails
-   'config' -  An object that can contain data, contentType, dataType, beforeSend function
+   'config' -  An object that can contain dataType, beforeSend function
     handleFormSubmit handles form submit, serializes the form values,
       disables the submit button to prevent double submit,
       displays the loading indicator and submits the form via ajax.

--- a/baseframe/static/js/baseframe-material.js
+++ b/baseframe/static/js/baseframe-material.js
@@ -294,14 +294,13 @@ window.Baseframe.Forms = {
    'formSelector' - Form selector to query the DOM for the form
    'onSuccess' - A callback function that is executed if the request succeeds
    'onError' - A callback function that is executed if the request fails
-   'config' -  An object that can contain data, contentType, dataType, 
-      beforeSend function
-    submitForm handles form submit, serializes the form values,
+   'config' -  An object that can contain data, contentType, dataType, beforeSend function
+    handleFormSubmit handles form submit, serializes the form values,
       disables the submit button to prevent double submit,
       displays the loading indicator and submits the form via ajax.
       On completing the ajax request, calls the onSuccess/onError callback function.
   */
-  submitForm: function(url, formSelector, onSuccess, onError, config) {
+  handleFormSubmit: function(url, formSelector, onSuccess, onError, config) {
     $(formSelector).find('button[type="submit"]').click(function(event) {
       event.preventDefault();
       $.ajax({

--- a/baseframe/static/js/baseframe-material.js
+++ b/baseframe/static/js/baseframe-material.js
@@ -294,7 +294,7 @@ window.Baseframe.Forms = {
    'formSelector' - Form selector to query the DOM for the form
    'onSuccess' - A callback function that is executed if the request succeeds
    'onError' - A callback function that is executed if the request fails
-   'config' -  An object that can contain data, contentType, dataType, beforeSend function
+   'config' -  An object that can contain dataType, beforeSend function
     handleFormSubmit handles form submit, serializes the form values,
       disables the submit button to prevent double submit,
       displays the loading indicator and submits the form via ajax.

--- a/baseframe/static/js/baseframe-material.js
+++ b/baseframe/static/js/baseframe-material.js
@@ -288,6 +288,28 @@ window.Baseframe.Forms = {
         }
       }
     });
+  },
+  handleAjaxPost: function(config) {
+    $(config.formSelector).find('button[type="submit"]').click(function(event) {
+      event.preventDefault();
+      $.ajax({
+        url: config.url,
+        type: 'POST',
+        data: config.data ? config.data : $.param($(config.formSelector).serializeArray()),
+        contentType : config.contentType ? config.contentType : 'application/x-www-form-urlencoded; charset=UTF-8',
+        dataType: config.dataType ? config.dataType : 'json',
+        beforeSend: function() {
+          if (config.formSelector) {
+            $(config.formSelector).find('button[type="submit"]').prop('disabled', true);
+            $(config.formSelector).find(".loading").removeClass('hidden');
+          }
+        }
+      }).done(function (remoteData) {
+        config.onSuccess(config, remoteData);
+      }).fail(function (response) {
+        config.onError(config, response);
+      });
+    });
   }
 };
 

--- a/baseframe/static/js/baseframe-material.js
+++ b/baseframe/static/js/baseframe-material.js
@@ -289,9 +289,9 @@ window.Baseframe.Forms = {
       }
     });
   },
-  /* Takes formSelector, url, onSuccess, onError, config
+  /* Takes formId, url, onSuccess, onError, config
+   'formId' - Form id selector to query the DOM for the form
    'url' - The url to which the post request is sent
-   'formSelector' - Form selector to query the DOM for the form
    'onSuccess' - A callback function that is executed if the request succeeds
    'onError' - A callback function that is executed if the request fails
    'config' -  An object that can contain dataType, beforeSend function
@@ -300,19 +300,19 @@ window.Baseframe.Forms = {
       displays the loading indicator and submits the form via ajax.
       On completing the ajax request, calls the onSuccess/onError callback function.
   */
-  handleFormSubmit: function(url, formSelector, onSuccess, onError, config) {
-    $(formSelector).find('button[type="submit"]').click(function(event) {
+  handleFormSubmit: function(formId, url, onSuccess, onError, config) {
+    $("#" + formId).find('button[type="submit"]').click(function(event) {
       event.preventDefault();
       $.ajax({
         url: url,
         type: 'POST',
-        data: $(formSelector).serialize(),
+        data: $("#" + formId).serialize(),
         dataType: config.dataType ? config.dataType : 'json',
         beforeSend: function() {
           // Disable submit button to prevent double submit
-          $(formSelector).find('button[type="submit"]').prop('disabled', true);
+          $("#" + formId).find('button[type="submit"]').prop('disabled', true);
           // Baseframe form has a loading indication which is hidden by default. Show the loading indicator
-          $(formSelector).find(".loading").removeClass('hidden');
+          $("#" + formId).find(".loading").removeClass('hidden');
           if (config.beforeSend) config.beforeSend();
         }
       }).done(function (remoteData) {

--- a/baseframe/static/js/baseframe-material.js
+++ b/baseframe/static/js/baseframe-material.js
@@ -308,8 +308,7 @@ window.Baseframe.Forms = {
       $.ajax({
         url: url,
         type: 'POST',
-        data: config.data ? config.data : $(formSelector).serialize(),
-        contentType : config.contentType ? config.contentType : 'application/x-www-form-urlencoded; charset=UTF-8',
+        data: $(formSelector).serialize(),
         dataType: config.dataType ? config.dataType : 'json',
         beforeSend: function() {
           // Disable submit button to prevent double submit

--- a/baseframe/static/js/baseframe-material.js
+++ b/baseframe/static/js/baseframe-material.js
@@ -318,9 +318,9 @@ window.Baseframe.Forms = {
           if (config.beforeSend) config.beforeSend();
         }
       }).done(function (remoteData) {
-        onSuccess(config, remoteData);
+        onSuccess(remoteData);
       }).fail(function (response) {
-        onError(config, response);
+        onError(response);
       });
     });
   }

--- a/baseframe/static/js/baseframe-material.js
+++ b/baseframe/static/js/baseframe-material.js
@@ -295,8 +295,7 @@ window.Baseframe.Forms = {
    'onSuccess' - A callback function that is executed if the request succeeds
    'onError' - A callback function that is executed if the request fails
    'config' -  An object that can contain data, contentType, dataType, 
-      beforeSend function or any other data required by the client 
-      during the execution of the onSuccess/OnError callback
+      beforeSend function
     submitForm handles form submit, serializes the form values,
       disables the submit button to prevent double submit,
       displays the loading indicator and submits the form via ajax.

--- a/baseframe/static/js/baseframe-material.js
+++ b/baseframe/static/js/baseframe-material.js
@@ -250,8 +250,8 @@ window.Baseframe.Forms = {
       }
     })
   },
-  /* Takes 'formSelector' and 'errors'
-     'formSelector' is the form for which errors needs to be displayed
+  /* Takes 'formId' and 'errors'
+     'formId' is the id attribute of the form for which errors needs to be displayed
      'errors' is the WTForm validation errors expected in the following format
       {
         "title": [
@@ -267,8 +267,8 @@ window.Baseframe.Forms = {
     using the unique form id. And the newly created 'p' tag
     is inserted in the DOM below the field.
   */
-  showValidationErrors: function(formSelector, errors) {
-    var form = document.querySelector(formId);
+  showValidationErrors: function(formId, errors) {
+    var form = document.getElementById(formId);
     Object.keys(errors).forEach(function(fieldName) {
       if (Array.isArray(errors[fieldName])) {
         var fieldWrapper = form.querySelector("#field-" + fieldName);

--- a/baseframe/templates/baseframe/bootstrap3/ajaxform.html.jinja2
+++ b/baseframe/templates/baseframe/bootstrap3/ajaxform.html.jinja2
@@ -1,7 +1,7 @@
 {% from "baseframe/bootstrap3/forms.html.jinja2" import renderform, ajaxform, widget_ext_scripts, widgetscripts %}
 {{ renderform(form=form, formid=formid, ref_id=ref_id, submit=submit, message=message, cancel_url=cancel_url, multipart=multipart) }}
 {%- if with_chrome -%}
-	{{ ajaxform(ref_id=ref_id, request=request, force=true) }}
+  {{ ajaxform(ref_id=ref_id, request=request, force=true) }}
 {%- endif -%}
 
 {{ widget_ext_scripts(form) }}

--- a/baseframe/templates/baseframe/bootstrap3/ajaxform.html.jinja2
+++ b/baseframe/templates/baseframe/bootstrap3/ajaxform.html.jinja2
@@ -1,6 +1,8 @@
 {% from "baseframe/bootstrap3/forms.html.jinja2" import renderform, ajaxform, widget_ext_scripts, widgetscripts %}
 {{ renderform(form=form, formid=formid, ref_id=ref_id, submit=submit, message=message, cancel_url=cancel_url, multipart=multipart) }}
-{{ ajaxform(ref_id=ref_id, request=request, force=true) }}
+{%- if with_chrome -%}
+	{{ ajaxform(ref_id=ref_id, request=request, force=true) }}
+{%- endif -%}
 
 {{ widget_ext_scripts(form) }}
 

--- a/baseframe/templates/baseframe/mui/ajaxform.html.jinja2
+++ b/baseframe/templates/baseframe/mui/ajaxform.html.jinja2
@@ -2,7 +2,7 @@
 {% from "baseframe/mui/forms.html.jinja2" import renderform, ajaxform, widget_ext_scripts, widgetscripts %}
 {{ renderform(form=form, formid=formid, ref_id=ref_id, submit=submit, message=message, cancel_url=cancel_url, multipart=multipart) }}
 {%- if with_chrome -%}
-	{{ ajaxform(ref_id=ref_id, request=request, force=true) }}
+  {{ ajaxform(ref_id=ref_id, request=request, force=true) }}
 {%- endif -%}
 
 {{ widget_ext_scripts(form) }}

--- a/baseframe/templates/baseframe/mui/ajaxform.html.jinja2
+++ b/baseframe/templates/baseframe/mui/ajaxform.html.jinja2
@@ -1,7 +1,9 @@
 <div>
 {% from "baseframe/mui/forms.html.jinja2" import renderform, ajaxform, widget_ext_scripts, widgetscripts %}
 {{ renderform(form=form, formid=formid, ref_id=ref_id, submit=submit, message=message, cancel_url=cancel_url, multipart=multipart) }}
-{{ ajaxform(ref_id=ref_id, request=request, force=true) }}
+{%- if with_chrome -%}
+	{{ ajaxform(ref_id=ref_id, request=request, force=true) }}
+{%- endif -%}
 
 {{ widget_ext_scripts(form) }}
 


### PR DESCRIPTION
Add `handleAjaxPost` function to `Baseframe.Forms`
This takes care of AJAX post requests for a client app given a URL, custom call backs for success & error scenarios.

Fixes #179 
