### PR TITLE
Fix autofocus bug

### DIFF
--- a/baseframe/templates/baseframe/bootstrap3/forms.html.jinja2
+++ b/baseframe/templates/baseframe/bootstrap3/forms.html.jinja2
@@ -111,13 +111,15 @@
   {% if message %}<p>{{ message }}</p>{% endif %}
   <div style="display:none;"><input type="hidden" name="form.id" value="{{ formid }}" /></div>
   {{ form.hidden_tag() }}
-  {%- set autofocus = true %}
   {% for field in form -%}
     {%- if field.type in ['CSRFTokenField', 'HiddenField'] -%}
       {# Don't show hidden #}
     {%- else -%}
-      {{ renderfield(field, autofocus=autofocus, style=style) }}
-      {%- if autofocus %}{% set autofocus = false %}{% endif %}
+      {% if loop.first %}
+        {{ renderfield(field, autofocus=true, style=style) }}
+      {%- else -%}
+        {{ renderfield(field, style=style) }}
+      {% endif %}
     {%- endif %}
   {% endfor %}
 {%- endmacro %}

--- a/baseframe/templates/baseframe/bootstrap3/forms.html.jinja2
+++ b/baseframe/templates/baseframe/bootstrap3/forms.html.jinja2
@@ -111,15 +111,34 @@
   {% if message %}<p>{{ message }}</p>{% endif %}
   <div style="display:none;"><input type="hidden" name="form.id" value="{{ formid }}" /></div>
   {{ form.hidden_tag() }}
+  <!--  In jinja, global scoped variables can't be modified inside a loop. https://github.com/pallets/jinja/issues/641. Hence using a dictionary to set autofocus and check if it is first field.
+  Autofocus is set true for the first field of the form provided it is not radio or checkbox.
+  In case of validation errors, autofocus is set true for the first field with an error.-->
+  {% set autofocus = {'set':false, 'first_field': false} %}
   {% for field in form -%}
     {%- if field.type in ['CSRFTokenField', 'HiddenField'] -%}
       {# Don't show hidden #}
     {%- else -%}
-      {% if loop.first %}
-        {{ renderfield(field, autofocus=true, style=style) }}
+      {%- if form.errors %}
+        {% if not autofocus.first_field %}
+          {% if field.errors %}
+            {% if autofocus.update({'set': true}) %}{% endif %}
+            {% if autofocus.update({'first_field': true}) %}{% endif %}
+          {% endif %}
+        {%- else -%}
+          {% if autofocus.update({'set': false}) %}{% endif %}
+        {% endif %}
       {%- else -%}
-        {{ renderfield(field, style=style) }}
+        {% if not autofocus.first_field %}
+          {% if field.type != 'RadioField' and field.type != 'BooleanField' %}
+            {% if autofocus.update({'set': true}) %}{% endif %}
+            {% if autofocus.update({'first_field': true}) %}{% endif %}
+          {% endif %}
+        {%- else -%}
+          {% if autofocus.update({'set': false}) %}{% endif %}
+        {% endif %}
       {% endif %}
+      {{ renderfield(field, autofocus=autofocus.set, style=style) }}
     {%- endif %}
   {% endfor %}
 {%- endmacro %}

--- a/baseframe/templates/baseframe/mui/forms.html.jinja2
+++ b/baseframe/templates/baseframe/mui/forms.html.jinja2
@@ -128,13 +128,34 @@
   {% if message %}<p>{{ message }}</p>{% endif %}
   <div style="display:none;"><input type="hidden" name="form.id" value="{{ formid }}" /></div>
   {{ form.hidden_tag() }}
-  {%- set autofocus = true %}
+   <!--  In jinja, global scoped variables can't be modified inside a loop. https://github.com/pallets/jinja/issues/641. Hence using a dictionary to set autofocus and check if it is first field.
+  Autofocus is set true for the first field of the form provided it is not radio or checkbox.
+  In case of validation errors, autofocus is set true for the first field with an error.-->
+  {% set autofocus = {'set':false, 'first_field': false} %}
   {% for field in form -%}
     {%- if field.type in ['CSRFTokenField', 'HiddenField'] -%}
       {# Don't show hidden #}
     {%- else -%}
-      {{ renderfield(field, autofocus=autofocus, style=style) }}
-      {%- if autofocus %}{% set autofocus = false %}{% endif %}
+      {%- if form.errors %}
+        {% if not autofocus.first_field %}
+          {% if field.errors %}
+            {% if autofocus.update({'set': true}) %}{% endif %}
+            {% if autofocus.update({'first_field': true}) %}{% endif %}
+          {% endif %}
+        {%- else -%}
+          {% if autofocus.update({'set': false}) %}{% endif %}
+        {% endif %}
+      {%- else -%}
+        {% if not autofocus.first_field %}
+          {% if field.type != 'RadioField' and field.type != 'BooleanField' %}
+            {% if autofocus.update({'set': true}) %}{% endif %}
+            {% if autofocus.update({'first_field': true}) %}{% endif %}
+          {% endif %}
+        {%- else -%}
+          {% if autofocus.update({'set': false}) %}{% endif %}
+        {% endif %}
+      {% endif %}
+      {{ renderfield(field, autofocus=autofocus.set, style=style) }}
     {%- endif %}
   {% endfor %}
 {%- endmacro %}


### PR DESCRIPTION
From Jinja 2.9, global scoped variables can't be modified inside a loop. https://github.com/pallets/jinja/issues/641. Hence using a dictionary to set autofocus and to check if it is first field of the form

Checks to set autofocus
Autofocus is set for the first field of the form provided it is not radio or checkbox.
In case of validation errors, autofocus is set for the first field of the form with an error.

