### PR TITLE
Don't disable submit button incase of client side form validation error

### DIFF
--- a/baseframe/templates/baseframe/bootstrap3/autoform.html.jinja2
+++ b/baseframe/templates/baseframe/bootstrap3/autoform.html.jinja2
@@ -15,12 +15,18 @@
       {{ widgetscripts(form, script=false) }}
     });
   </script>
-  {{ ajaxform(ref_id=ref_id, request=request, force=ajax) }}
   <script src="{{ 'parsley.js'|ext_asset_url }}" type="text/javascript"></script>
   <script type="text/javascript">
     // In a separate script block in case the autosize plugin isn't present
     $(function() {
       $('textarea').autosize();
+      $('#{{ ref_id }}').parsley().subscribe('parsley:field:validated', function(){
+        if ($('#{{ ref_id }}').parsley().isValid())
+          $('#{{ ref_id }}').addClass('parsley-valid').removeClass('parsley-invalid');
+        else
+          $('#{{ ref_id }}').addClass('parsley-invalid').removeClass('parsley-valid');
+      });
     })
   </script>
+  {{ ajaxform(ref_id=ref_id, request=request, force=ajax) }}
 {% endblock %}

--- a/baseframe/templates/baseframe/bootstrap3/forms.html.jinja2
+++ b/baseframe/templates/baseframe/bootstrap3/forms.html.jinja2
@@ -126,7 +126,7 @@
 {%- endmacro %}
 
 {%- macro renderform(form, formid, submit, ref_id='form', message='', action=None, cancel_url='', multipart=false, style='horiz', autosave=False, draft_revision=None) %}
-<form data-parsley-validate id="{{ ref_id }}" method="POST" {%- if action %} action="{{ action }}" {%- endif %}{%- if multipart %} enctype="multipart/form-data" {%- endif %} accept-charset="UTF-8" {%- if style == 'horiz' %} class="form-horizontal"{% endif %}>
+<form data-parsley-validate="true" id="{{ ref_id }}" method="POST" {%- if action %} action="{{ action }}" {%- endif %}{%- if multipart %} enctype="multipart/form-data" {%- endif %} accept-charset="UTF-8" {%- if style == 'horiz' %} class="form-horizontal"{% endif %}>
   {{ renderform_inner(form, formid or none, style=style, autosave=autosave, draft_revision=draft_revision) }}
   {{ rendersubmit([(none, submit or _("Submit"), 'btn-primary')], cancel_url=cancel_url, style=style, csrf_error=form.csrf_token.errors) }}
 </form>
@@ -160,9 +160,11 @@
       $(function() {
         // Disable submit button when clicked. Prevent double click.
         $('#{{ ref_id }}').submit(function() {
-          $(this).find('button[type="submit"]').addClass('submit-disabled').prop('disabled', true);
-          $(this).find('input[type="submit"]').prop('disabled', true).addClass('submit-disabled');
-          $(this).find(".loading").removeClass('hidden');
+          if(!$(this).data('parsley-validate') ||  $(this).data('parsley-validate') && $(this).hasClass('parsley-valid')) {
+            $(this).find('button[type="submit"]').prop('disabled', true);
+            $(this).find('input[type="submit"]').prop('disabled', true);
+            $(this).find(".loading").removeClass('mui--hide');
+          }
         });
       });
     </script>

--- a/baseframe/templates/baseframe/mui/autoform.html.jinja2
+++ b/baseframe/templates/baseframe/mui/autoform.html.jinja2
@@ -15,6 +15,17 @@
       {{ widgetscripts(form, script=false) }}
     });
   </script>
-  {{ ajaxform(ref_id=ref_id, request=request, force=ajax) }}
   <script src="{{ 'parsley.js'|ext_asset_url }}" type="text/javascript"></script>
+  <script type="text/javascript">
+    // In a separate script block in case the autosize plugin isn't present
+    $(function() {
+      $('#{{ ref_id }}').parsley().subscribe('parsley:field:validated', function(){
+        if ($('#{{ ref_id }}').parsley().isValid())
+          $('#{{ ref_id }}').addClass('parsley-valid').removeClass('parsley-invalid');
+        else
+          $('#{{ ref_id }}').addClass('parsley-invalid').removeClass('parsley-valid');
+      });
+    })
+  </script>
+  {{ ajaxform(ref_id=ref_id, request=request, force=ajax) }}
 {% endblock %}

--- a/baseframe/templates/baseframe/mui/forms.html.jinja2
+++ b/baseframe/templates/baseframe/mui/forms.html.jinja2
@@ -145,7 +145,7 @@
 {%- endmacro %}
 
 {%- macro renderform(form, formid, submit, ref_id='form', message='', action=None, cancel_url='', multipart=false, style='', autosave=False, draft_revision=None) %}
-<form data-parsley-validate id="{{ ref_id }}" method="POST" {%- if action %} action="{{ action }}" {%- endif %}{%- if multipart %} enctype="multipart/form-data" {%- endif %} accept-charset="UTF-8" class="mui-form mui-form--margins hg-form {%- if style == 'horiz' %} mui-form--inline{% endif %}">
+<form data-parsley-validate="true" id="{{ ref_id }}" method="POST" {%- if action %} action="{{ action }}" {%- endif %}{%- if multipart %} enctype="multipart/form-data" {%- endif %} accept-charset="UTF-8" class="mui-form mui-form--margins hg-form {%- if style == 'horiz' %} mui-form--inline{% endif %}">
   {{ renderform_inner(form, formid or none, style=style, autosave=autosave, draft_revision=draft_revision) }}
   {{ rendersubmit([(none, submit or _("Submit"), 'mui-btn--primary')], cancel_url=cancel_url, style=style, csrf_error=form.csrf_token.errors) }}
 </form>
@@ -179,9 +179,11 @@
       $(function() {
         // Disable submit button when clicked. Prevent double click.
         $('#{{ ref_id }}').submit(function() {
-          $(this).find('button[type="submit"]').prop('disabled', true);
-          $(this).find('input[type="submit"]').prop('disabled', true);
-          $(this).find(".loading").removeClass('mui--hide');
+          if(!$(this).data('parsley-validate') ||  $(this).data('parsley-validate') && $(this).hasClass('parsley-valid')) {
+            $(this).find('button[type="submit"]').prop('disabled', true);
+            $(this).find('input[type="submit"]').prop('disabled', true);
+            $(this).find(".loading").removeClass('mui--hide');
+          }
         });
       });
     </script>


### PR DESCRIPTION
To prevent double click, submit button was disabled and form was submitted even when there is client side validation errors(parsley.js). 
Added a fix to check if the form has client side validation enabled, if so then only when the form has no validation errors, the submit button is disabled to prevent double click.