### PR TITLE
Babel2 fix + werkzeug pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
     tests_require=['Flask-SQLAlchemy'],
     cmdclass={'build_py': BaseframeBuildPy},
     dependency_links=[
-        "git+https://github.com/hasgeek/coaster#egg=coaster-dev",
-        "git+https://github.com/hasgeek/flask-babel2#egg=flask_babel2"
+        "https://github.com/hasgeek/coaster/archive/master.zip#egg=coaster-dev",
+        "https://github.com/hasgeek/flask-babel2/archive/master.zip#egg=Flask-Babel2-0.12.3"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ requires = [
     'pyOpenSSL',
     'ndg-httpsclient',
     'pyasn1',
+    'werkzeug==0.16.1'
 ]
 
 


### PR DESCRIPTION
Werkzeug has bumped up their version to [`1.0.0rc1`](https://pypi.org/project/Werkzeug/#history) and changed their top level imports, which has broken Flask-WTF and Flask-Babel2. We're patching Flask-Babel2 but we need to pin werkzeug until Flask-WTF is patched.