### PR TITLE
Expanded capabilities in ValidUrl

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,9 +1,13 @@
 version = 1
 
+test_patterns = [
+  "tests/**"
+]
+
 [[analyzers]]
 name = "python"
 enabled = true
-runtime_version = "3.x.x"
+runtime_version = "2.x.x"
 
 [analyzers.meta]
 max_line_length = 100

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -4,6 +4,10 @@ test_patterns = [
   "tests/**"
 ]
 
+exclude_patterns = [
+  "baseframe/static/**"
+]
+
 [[analyzers]]
 name = "python"
 enabled = true

--- a/baseframe/forms/form.py
+++ b/baseframe/forms/form.py
@@ -176,7 +176,7 @@ class Form(BaseForm):
             form_validation_success.send(self)
 
     def errors_with_data(self):
-        # Convert lazy_gettext error strings into str so they don't cause problems downstream
+        # Convert lazy_gettext error strings into unicode so they don't cause problems downstream
         # (like when pickling)
         return {
             name: {

--- a/baseframe/forms/form.py
+++ b/baseframe/forms/form.py
@@ -176,7 +176,7 @@ class Form(BaseForm):
             form_validation_success.send(self)
 
     def errors_with_data(self):
-        # Convert lazy_gettext error strings into unicode so they don't cause problems downstream
+        # Convert lazy_gettext error strings into str so they don't cause problems downstream
         # (like when pickling)
         return {
             name: {

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ requires = [
     'Flask-WTF>=0.14',
     'Flask>=1.0',
     'furl',
-    'lxml',
+    'html5lib>=1.0.1',
     'mxsniff',
     'ndg-httpsclient',
     'pyasn1',


### PR DESCRIPTION
* Support a list of allowed schemes and domains
* Optionally disable URL tester
* Use html5lib instead of lxml for parsing safety
* Misc linter fixes