### PR TITLE
Remove full height modal. Add full height for modal forms. Fix the au…

### DIFF
--- a/baseframe/static/css/mui.css
+++ b/baseframe/static/css/mui.css
@@ -4440,10 +4440,7 @@ li p + ol {
   display: inline-block;
   overflow: hidden;
   padding: 16px;
-  width: 100%;
-  min-height: 100%;
-  max-width: 100%;
-  border-radius: 0;
+  border-radius: 8px;
 }
 .jquery-modal.blocker.current .modal a.close-modal {
   display: none;
@@ -4456,6 +4453,12 @@ li p + ol {
 }
 .jquery-modal.blocker.current .modal .modal__body__btn {
   margin-top: 16px;
+}
+.jquery-modal.blocker.current .modal-form {
+  width: 100%;
+  border-radius: 0;
+  overflow: auto;
+  min-height: 100%;
 }
 
 @media (min-width: 768px) {

--- a/baseframe/static/sass/baseframe-material/_modal.scss
+++ b/baseframe/static/sass/baseframe-material/_modal.scss
@@ -10,10 +10,7 @@
     overflow: hidden;
     padding: $mui-grid-padding;
     @extend .mui--z1;
-    width: 100%;
-    min-height: 100%;
-    max-width: 100%;
-    border-radius: 0;
+    border-radius: 8px;
 
     //Use fa5 icon for close
     a.close-modal {
@@ -35,6 +32,12 @@
     .modal__body__btn {
       margin-top: $mui-grid-padding;
     }
+  }
+  .modal-form {
+    width: 100%;
+    border-radius: 0;
+    overflow: auto;
+    min-height: 100%;
   }
 }
 

--- a/baseframe/templates/baseframe/mui/forms.html.jinja2
+++ b/baseframe/templates/baseframe/mui/forms.html.jinja2
@@ -156,12 +156,13 @@
     <input type="hidden" name="form.revision" value="{{ draft_revision if draft_revision is not none }}" />
   {%- endif %}
   {%- set autofocus = true %}
+  {% set autofocus = namespace(val=true) %}
   {% for field in form -%}
     {%- if field.type in ['CSRFTokenField', 'HiddenField', 'NonceField'] -%}
       {# Don't show hidden #}
     {%- else -%}
-      {{ renderfield(field, autofocus=autofocus, style=style) }}
-      {%- if autofocus %}{% set autofocus = false %}{% endif %}
+      {{ renderfield(field, autofocus=autofocus.val, style=style) }}
+      {%- if autofocus.val %}{% set autofocus.val = false %}{% endif %}
     {%- endif %}
   {% endfor %}
 {%- endmacro %}


### PR DESCRIPTION
1. Remove 100% height for modals in mobile. 
2. Add 100% height for modals with form. 
3. Fix the autofocus value in the form template. Global variable can't be modified inside for loop so using `namespace`.