### PR TITLE
Reintroduce speaklater as a dependency

### DIFF
--- a/baseframe/__init__.py
+++ b/baseframe/__init__.py
@@ -14,7 +14,8 @@ from flask import Blueprint, current_app, request
 from flask.json import JSONEncoder as JSONEncoderBase
 from flask_assets import Bundle, Environment
 from flask_babelhg import Babel, Domain, ctx_has_locale
-from flask_babelhg.speaklater import is_lazy_string
+from flask_babelhg.speaklater import is_lazy_string as is_lazy_string_hg
+from speaklater import is_lazy_string as is_lazy_string_sl
 
 from babel import Locale
 from flask_caching import Cache
@@ -102,6 +103,11 @@ THEME_FILES = {
 baseframe_translations = Domain(translations.__path__[0], domain='baseframe')
 _ = baseframe_translations.gettext
 __ = baseframe_translations.lazy_gettext
+
+
+def is_lazy_string(string):
+    # Some lazy strings are from the speaklater library, some from Flask-Babelhg's fork
+    return is_lazy_string_hg(string) or is_lazy_string_sl(string)
 
 
 class JSONEncoder(JSONEncoderBase):

--- a/baseframe/forms/form.py
+++ b/baseframe/forms/form.py
@@ -6,13 +6,13 @@ from threading import Lock
 import uuid
 
 from flask import current_app
-from flask_babelhg.speaklater import is_lazy_string
 from flask_wtf import FlaskForm as BaseForm
 from wtforms.compat import iteritems
 import wtforms
 
 from .. import asset_cache
 from .. import b__ as __
+from .. import is_lazy_string
 from ..signals import form_validation_error, form_validation_success
 from . import fields as bfields
 from . import filters as bfilters

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ requires = [
     'semantic_version',
     'sentry-sdk',
     'six>=1.13.0',
+    'speaklater',
     'statsd',
     'werkzeug',
     'WTForms>=2.2',


### PR DESCRIPTION
An upstream library, possibly WTForms, is using speaklater's `_LazyString` class, so we must test for that.