### PR TITLE
Adding transaction sampling to sentry

### DIFF
--- a/baseframe/blueprint.py
+++ b/baseframe/blueprint.py
@@ -112,11 +112,11 @@ class BaseframeBlueprint(Blueprint):
             # With `traces_sample_rate` option set, every transaction created will
             # have that percentage chance of being sent to Sentry. (So, for example,
             # if you set traces_sample_rate to 0.2, approximately 20% of your
-            # transactions will get recorded and sent.) We're keeping it 100% by
-            # default, but we can reduce it from app.config if needed.
+            # transactions will get recorded and sent.) We're keeping it 50% by
+            # default, but we can change it from app.config if needed.
             sentry_sdk.init(
                 dsn=app.config['SENTRY_URL'],
-                traces_sample_rate=app.config.get('SENTRY_SAMPLE_RATE', 1),
+                traces_sample_rate=app.config.get('SENTRY_SAMPLE_RATE', 0.5),
                 integrations=[
                     FlaskIntegration(),
                     RqIntegration(),

--- a/baseframe/blueprint.py
+++ b/baseframe/blueprint.py
@@ -112,11 +112,11 @@ class BaseframeBlueprint(Blueprint):
             # With `traces_sample_rate` option set, every transaction created will
             # have that percentage chance of being sent to Sentry. (So, for example,
             # if you set traces_sample_rate to 0.2, approximately 20% of your
-            # transactions will get recorded and sent.) We're keeping it 50% by
+            # transactions will get recorded and sent.) We're keeping it 100% by
             # default, but we can change it from app.config if needed.
             sentry_sdk.init(
                 dsn=app.config['SENTRY_URL'],
-                traces_sample_rate=app.config.get('SENTRY_SAMPLE_RATE', 0.5),
+                traces_sample_rate=app.config.get('SENTRY_SAMPLE_RATE', 1.0),
                 integrations=[
                     FlaskIntegration(),
                     RqIntegration(),

--- a/baseframe/blueprint.py
+++ b/baseframe/blueprint.py
@@ -109,8 +109,14 @@ class BaseframeBlueprint(Blueprint):
         """
         # Initialize Sentry logging
         if app.config.get('SENTRY_URL'):
+            # With `traces_sample_rate` option set, every transaction created will
+            # have that percentage chance of being sent to Sentry. (So, for example,
+            # if you set traces_sample_rate to 0.2, approximately 20% of your
+            # transactions will get recorded and sent.) We're keeping it 100% by
+            # default, but we can reduce it from app.config if needed.
             sentry_sdk.init(
                 dsn=app.config['SENTRY_URL'],
+                traces_sample_rate=app.config.get('SENTRY_SAMPLE_RATE', 1),
                 integrations=[
                     FlaskIntegration(),
                     RqIntegration(),


### PR DESCRIPTION
Sentry now has performance monitoring. We need to set a sampling rate for it to work. From [their doc](https://docs.sentry.io/platforms/python/guides/flask/performance/) - 

> Sentry allows you to monitor the performance of your application, showing you how latency in one service may affect another service, and letting you pinpoint exactly which parts of a given operation may be responsible. To do this, it captures distributed traces consisting of transactions and spans, which measure individual services and individual operations within those services, respectively. You can learn more about this model in our Distributed Tracing docs. Performance Monitoring is available for the Sentry Python SDK version ≥ 0.11.2.