### PR TITLE
Fixed emoji check in emoji validator

### DIFF
--- a/baseframe/forms/validators.py
+++ b/baseframe/forms/validators.py
@@ -326,7 +326,7 @@ class IsEmoji:
         self.message = message or self.default_message
 
     def __call__(self, form, field) -> None:
-        if field.data not in emoji.UNICODE_EMOJI:  # type: ignore[attr-defined]
+        if field.data not in emoji.UNICODE_EMOJI_ENGLISH:  # type: ignore[attr-defined]
             raise ValidationError(self.message)
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requires = [
     'coaster',
     'cssmin',
     'dnspython',
-    'emoji',
+    'emoji>=1.0.0',
     'Flask-Assets',
     'Flask-Babelhg',
     'Flask-Caching',


### PR DESCRIPTION
From version 1.0.0, the `emoji` package changed the way you can check for existence of an emoji in their dicts. This is why our label tests were breaking. This fixes that. 

ref: https://github.com/carpedm20/emoji/issues/155