### PR TITLE
Add Noto Sans Math for math symbols on ChromeOS

### DIFF
--- a/baseframe/static/css/mui.css
+++ b/baseframe/static/css/mui.css
@@ -1691,8 +1691,8 @@ html {
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
-    Ubuntu, Cantarell, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji',
-    'Segoe UI Emoji', 'Segoe UI Symbol';
+    Ubuntu, Cantarell, 'Helvetica Neue', Arial, sans-serif, 'Noto Sans Math',
+    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
   font-size: 14px;
   font-weight: 400;
   line-height: 21px;

--- a/baseframe/static/sass/mui/_custom.scss
+++ b/baseframe/static/sass/mui/_custom.scss
@@ -38,7 +38,7 @@ $mui-btn-danger-bg-color: $mui-text-danger;
 $mui-base-font-color: $mui-text-dark !default;
 $mui-base-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
   Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', Arial, sans-serif,
-  'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  'Noto Sans Math','Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 $mui-base-font-size: 14px !default;
 $mui-base-font-size-desktop: 16px !default;
 $mui-base-font-weight: 400 !default;

--- a/baseframe/static/sass/mui/_custom.scss
+++ b/baseframe/static/sass/mui/_custom.scss
@@ -38,7 +38,7 @@ $mui-btn-danger-bg-color: $mui-text-danger;
 $mui-base-font-color: $mui-text-dark !default;
 $mui-base-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
   Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', Arial, sans-serif,
-  'Noto Sans Math','Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  'Noto Sans Math', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 $mui-base-font-size: 14px !default;
 $mui-base-font-size-desktop: 16px !default;
 $mui-base-font-weight: 400 !default;


### PR DESCRIPTION
Roboto, the font for ChromeOS, is missing symbols, as a result of which several math symbols are rendered as emoji. Noto Sans Math contains these symbols, but since it's also a distinct typeface, it's added to the bottom of the stack.