### PR TITLE
Trap focus within modal to make it accessible using just keyboard

### DIFF
--- a/baseframe/static/css/mui.css
+++ b/baseframe/static/css/mui.css
@@ -3663,6 +3663,7 @@ h6 {
   height: auto;
   border: none;
   line-height: 1;
+  font-weight: normal;
 }
 
 .mui-btn.mui-btn--nostyle:hover,

--- a/baseframe/static/js/baseframe-material.js
+++ b/baseframe/static/js/baseframe-material.js
@@ -326,10 +326,10 @@ window.Baseframe.Forms = {
      'errors' is the WTForm validation errors expected in the following format
       {
         "title": [
-          "This field is required."
+          "This field is required"
         ]
         "email": [
-          "Not a valid email."
+          "Not a valid email"
         ]
       }
     For each error, a 'p' tag is created if not present and

--- a/baseframe/static/js/baseframe-material.js
+++ b/baseframe/static/js/baseframe-material.js
@@ -186,7 +186,6 @@ function trapFocusWithinModal(modal) {
   var focusableItems = children.filter(focusableElems).filter(':visible');
   var numberOfFocusableItems = focusableItems.length;
   var focusedItem, focusedItemIndex;
-  $this.click();
   $this.find('.modal__close').focus();
 
   $this.on('keydown', function (event) {

--- a/baseframe/static/js/baseframe-material.js
+++ b/baseframe/static/js/baseframe-material.js
@@ -166,6 +166,44 @@ function activateZoomPopup() {
   });
 }
 
+function addFocusOnModalShow() {
+  var focussedElem;
+  $('body').on($.modal.OPEN, '.modal', function () {
+    focussedElem = document.activeElement;
+    trapFocusWithinModal(this);
+  });
+
+  $('body').on($.modal.CLOSE, '.modal', function () {
+    focussedElem.focus();
+  });
+}
+
+function trapFocusWithinModal(modal) {
+  var $this = $(modal);
+  var focusableElems =
+    'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]';
+  var children = $this.find('*');
+  var focusableItems = children.filter(focusableElems).filter(':visible');
+  var numberOfFocusableItems = focusableItems.length;
+  var focusedItem, focusedItemIndex;
+  $this.click();
+  $this.find('.modal__close').focus();
+
+  $this.on('keydown', function (event) {
+    if (event.keyCode != 9) return;
+    focusedItem = $(document.activeElement);
+    focusedItemIndex = focusableItems.index(focusedItem);
+    if (!event.shiftKey && focusedItemIndex == numberOfFocusableItems - 1) {
+      focusableItems.get(0).focus();
+      event.preventDefault();
+    }
+    if (event.shiftKey && focusedItemIndex == 0) {
+      focusableItems.get(numberOfFocusableItems - 1).focus();
+      event.preventDefault();
+    }
+  });
+}
+
 $(function () {
   // activate all widgets
   activate_widgets();
@@ -289,10 +327,10 @@ window.Baseframe.Forms = {
      'errors' is the WTForm validation errors expected in the following format
       {
         "title": [
-          "This field is required"
+          "This field is required."
         ]
         "email": [
-          "Not a valid email"
+          "Not a valid email."
         ]
       }
     For each error, a 'p' tag is created if not present and
@@ -560,4 +598,5 @@ $(function () {
   });
 
   activateZoomPopup();
+  addFocusOnModalShow();
 });

--- a/baseframe/static/sass/baseframe-material/_helper.scss
+++ b/baseframe/static/sass/baseframe-material/_helper.scss
@@ -166,6 +166,7 @@ h6 {
   height: auto;
   border: none;
   line-height: 1;
+  font-weight: normal;
 }
 
 .mui-btn.mui-btn--nostyle:hover,


### PR DESCRIPTION
Reference
1. https://developers.google.com/web/fundamentals/accessibility/focus/using-tabindex#modals_and_keyboard_traps
2. https://bitsofco.de/accessible-modal-dialog/
3. https://uxdesign.cc/how-to-trap-focus-inside-modal-to-make-it-ada-compliant-6a50f9a70700