### PR TITLE
Remove support for external asset server

### DIFF
--- a/baseframe/blueprint.py
+++ b/baseframe/blueprint.py
@@ -95,11 +95,9 @@ class BaseframeBlueprint(Blueprint):
             Loaded assets will be minified and concatenated into the app's
             ``static/js`` and ``static/css`` folders. If an asset has problems
             with either of these, it should be loaded pre-bundled via the
-            ``bundle_js`` and ``bundle_css`` parameters.
-        :param ext_requires: Same as requires, but will be loaded from
-            an external cookiefree server if ``ASSET_SERVER`` is in config,
-            before the reqular requires list. Assets are loaded as part of
-            ``requires`` if there is no asset server
+            ``bundle_js`` and ``bundle_css`` parameters
+        :param ext_requires: Extended requirements, will be loaded first. These used to
+            be served from a separate asset server, but that is deprecated
         :param bundle_js: Bundle of additional JavaScript
         :param bundle_css: Bundle of additional CSS
         :param theme: CSS theme, one of 'bootstrap3' (default) or 'mui'
@@ -177,33 +175,13 @@ class BaseframeBlueprint(Blueprint):
         ignore_css: List[str] = []
         ext_js: List[List[str]] = []
         ext_css: List[List[str]] = []
-        if app.config.get('ASSET_SERVER'):
-            for itemgroup in ext_requires:
-                sub_js: List[str] = []
-                sub_css: List[str] = []
-                if not isinstance(itemgroup, (list, tuple)):
-                    itemgroup = [itemgroup]
-                for item in itemgroup:
-                    name, spec = split_namespec(item)
-                    for alist, ilist, ext in [
-                        (sub_js, ignore_js, '.js'),
-                        (sub_css, ignore_css, '.css'),
-                    ]:
-                        if name + ext in assets:
-                            alist.append(name + ext + str(spec))
-                            ilist.append('!' + name + ext)
-                if sub_js:
-                    ext_js.append(sub_js)
-                if sub_css:
-                    ext_css.append(sub_css)
-        else:
-            requires = [
-                item
-                for itemgroup in ext_requires
-                for item in (
-                    itemgroup if isinstance(itemgroup, (list, tuple)) else [itemgroup]
-                )
-            ] + list(requires)
+        requires = [
+            item
+            for itemgroup in ext_requires
+            for item in (
+                itemgroup if isinstance(itemgroup, (list, tuple)) else [itemgroup]
+            )
+        ] + list(requires)
 
         app.config['ext_js'] = ext_js
         app.config['ext_css'] = ext_css

--- a/baseframe/views.py
+++ b/baseframe/views.py
@@ -25,7 +25,7 @@ from coaster.views import render_with
 
 from .assets import assets as assets_repo
 from .blueprint import baseframe
-from .extensions import asset_cache, networkbar_cache
+from .extensions import networkbar_cache
 from .utils import request_checked_xhr, request_timestamp
 
 
@@ -98,13 +98,8 @@ def gen_assets_url(assets: List[str]) -> str:
 
 def ext_assets(assets: List[str]) -> str:
     """Return a URL to the required external assets."""
-    key = asset_key(assets)
-    try:
-        url = asset_cache.get('assets/' + key)
-    except ValueError:  # Can happen due to Py2 vs Py3 pickle mismatch
-        url = None
-    if url:
-        return url
+    # XXX: External assets are deprecated, so this function serves them as internal
+    # assets
     return gen_assets_url(assets)
 
 

--- a/baseframe/views.py
+++ b/baseframe/views.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urlparse
 import os
 import os.path
 
@@ -105,27 +105,7 @@ def ext_assets(assets: List[str]) -> str:
         url = None
     if url:
         return url
-    if current_app.config.get('ASSET_SERVER'):
-        try:
-            r = requests.get(
-                urljoin(current_app.config['ASSET_SERVER'], 'asset'),
-                params={'a': assets},
-                allow_redirects=False,
-            )
-            if r.status_code in (301, 302, 303, 307):
-                url = r.headers['location']
-            else:  # XXX: What broke and failed to do a 3xx?
-                url = r.url
-            asset_cache.set(
-                'assets/' + key,
-                url,
-                timeout=current_app.config.get('ASSET_TIMEOUT', 60),
-            )
-            return url
-        except requests.exceptions.ConnectionError:
-            return gen_assets_url(assets)
-    else:
-        return gen_assets_url(assets)
+    return gen_assets_url(assets)
 
 
 def asset_path(bundle_key: str) -> str:


### PR DESCRIPTION
The [Cookiefree](/hasgeek/cookiefree) asset server has not had real utility for a while. It predated the switch to HTTPS-only websites. Modern use of the `Vary: Cookie` header (or its absence) can reliably guide a browser to cache static assets. Using an external domain only opens the door to CORS-related misconfiguration.

Cookiefree is not a CDN. A CDN for static files is still a good idea, but needs to be implemented separately.